### PR TITLE
Blend waypoints with zero velocity after shortcutting

### DIFF
--- a/include/or_parabolicsmoother/DynamicPath.h
+++ b/include/or_parabolicsmoother/DynamicPath.h
@@ -119,7 +119,7 @@ class DynamicPath
   inline void Clear() { ramps.clear(); }
   inline bool Empty() const { return ramps.empty(); }
   Real GetTotalTime() const;
-  int GetSegment(Real t,Real& u) const;
+  int GetSegment(Real t,Real& u,bool& outOfBounds) const;
   void Evaluate(Real t,Vector& x) const;
   void Derivative(Real t,Vector& dx) const;
   void SetMilestones(const std::vector<Vector>& x);

--- a/include/or_parabolicsmoother/ParabolicRamp.h
+++ b/include/or_parabolicsmoother/ParabolicRamp.h
@@ -106,6 +106,7 @@ class ParabolicRamp1D
 class ParabolicRampND
 {
  public:
+  ParabolicRampND();
   void SetConstant(const Vector& x,Real t=0);
   void SetLinear(const Vector& x0,const Vector& x1,Real t);
   bool SolveMinTimeLinear(const Vector& amax,const Vector& vmax);
@@ -133,6 +134,9 @@ class ParabolicRampND
   /// Calculated upon SolveX
   Real endTime;
   std::vector<ParabolicRamp1D> ramps;
+
+  /// Used for shortcutting.
+  int blendAttempts;
 };
 
 /// Computes a min-time ramp from (x0,v0) to (x1,v1) under the given

--- a/src/ParabolicRamp.cpp
+++ b/src/ParabolicRamp.cpp
@@ -1722,6 +1722,10 @@ bool ParabolicRamp1D::IsValid() const
 
 
 
+ParabolicRampND::ParabolicRampND()
+    : blendAttempts(-1)
+{
+}
 
 void ParabolicRampND::SetConstant(const Vector& x,Real t)
 {
@@ -2095,6 +2099,7 @@ void ParabolicRampND::SolveBraking(const Vector& amax)
 void ParabolicRampND::Evaluate(Real t,Vector& x) const
 {
   x.resize(ramps.size());
+
   for(size_t j=0;j<ramps.size();j++)
     x[j]=ramps[j].Evaluate(t);
 }


### PR DESCRIPTION
This pull request implements the "blending" feature that @aaronjoh, @psigen, @siddhss5, and I discussed this morning. We've anecdotally noticed that the trajectory produced by `or_parabolicsmoother` often still stops at waypoints. Our intuition is that this occurs because `or_parabolicsmoother` does not attempt to explicitly blend around waypoints. A waypoint is only blended if it happens to be removed as part of a shortcut.

We've modified `or_parabolicsmoother` to perform a second "blending" pass on the output trajectory. In this pass, we explicitly try to insert a short blend around any waypoints that have zero velocity. If such a waypoint occurs at time `t`, the "blend" operation tries to fit a spline from `t - dt` to `t + dt`. We search over several, decreasing values of `dt` to find a feasible blend. If all values fail, we leave the waypoint unmodified.

This is conceptually a fairly straightforward change, but @psigen and I discovered that it requires some very careful bookkeeping to avoid repeatedly trying to blend the same waypoint. Our final solution was to tag each waypoint with a `blendAttempts` counter, so we can try to blend each waypoint at most once for a given value of `dt`.

@aaronjoh @siddhss5: Any comments? Is this consistent with what we discussed this morning?

@cdellin: Could you take a look at our implementation? In particular, we had trouble figuring out the bookkeeping necessary in `DynamicPath::Evaluate`.