### PR TITLE
Fixes bug where last ramp would be shortcutted forever.

### DIFF
--- a/include/or_parabolicsmoother/Config.h
+++ b/include/or_parabolicsmoother/Config.h
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <openrave/openrave.h>
 
+#include "Math.h"
+
 ///assertion function
 #define PARABOLIC_RAMP_ASSERT(x)
 
@@ -29,7 +31,7 @@ namespace ParabolicRamp {
 
   ///self validity check level:
   ///- 0 no checking
-  ///- 1 moderate checking 
+  ///- 1 moderate checking
   ///- 2 full checking
   const static int gValidityCheckLevel = 2;
 


### PR DESCRIPTION
Due to numerical precision issues, it was possible for the TryBlend function to attempt a blend on the last ramp that did not include the last ramp, which led to the last ramp of a trajectory being shortcutted forever.  This fix extends the range of blends by EpsilonT, the configured time epsilon, to ensure that shortcutted ramps are included in that range.

It also cleans up some minor whitespace and reuses the EpsilonV argument where appropriate.