### PR TITLE
Removed duplicate first waypoint

### DIFF
--- a/src/ParabolicSmoother.cpp
+++ b/src/ParabolicSmoother.cpp
@@ -407,7 +407,6 @@ OpenRAVE::PlannerStatus ParabolicSmoother::PlanPath(TrajectoryBasePtr traj)
 
     // Insert the critical points into the output trajectory.
     double prev_t = 0.;
-    ConvertWaypoint(traj, dynamic_path, prev_t, 0.);
 
     BOOST_FOREACH (double const t, sample_times) {
         double const dt = t - prev_t;


### PR DESCRIPTION
This pull request fixes a bug that caused `or_parabolicsmoother` to always output two copies of the first waypoint. This happened because we manually add the first waypoint to the trajectory. This is not necessary because the first ramp always starts at time zero.