### PR TITLE
Fixes missing snap on sampling out-of-bounds past end of traj.

### DIFF
--- a/src/DynamicPath.cpp
+++ b/src/DynamicPath.cpp
@@ -135,7 +135,7 @@ int DynamicPath::GetSegment(Real t,Real& u,bool& outOfBounds) const
     }
     t -= ramps[i].endTime;
   }
-  u = t;
+  u = ramps.back().endTime;
   outOfBounds = true;
   return (int)ramps.size() - 1;
 }


### PR DESCRIPTION
This PR fixes an issue where times for samples past the end of
the trajectory were not snapped to the ramp end-time in the trajectory
the same way as the start times are snapped to `t=0`.