### PR TITLE
Feature: Using trajectory velocities

### DIFF
--- a/include/or_parabolicsmoother/ParabolicSmootherParameters.h
+++ b/include/or_parabolicsmoother/ParabolicSmootherParameters.h
@@ -14,12 +14,14 @@ public:
         , blend_iterations_(4)
         , do_shortcut_(true)
         , time_limit_(3.0)
+        , use_velocity_(true)
     {
         _vXMLParameters.push_back("do_blend");
         _vXMLParameters.push_back("do_shortcut");
         _vXMLParameters.push_back("time_limit");
         _vXMLParameters.push_back("blend_radius");
         _vXMLParameters.push_back("blend_iterations");
+        _vXMLParameters.push_back("use_velocity");
     }
 
     virtual void copy(boost::shared_ptr<PlannerParameters const> r)
@@ -33,6 +35,7 @@ public:
             blend_iterations_ = p->blend_iterations_;
             do_shortcut_ = p->do_shortcut_;
             time_limit_ = p->time_limit_;
+            use_velocity_ = p->use_velocity_;
         }
 
         PlannerParameters::copy(r);
@@ -49,6 +52,8 @@ public:
 
     double time_limit_;
 
+    bool use_velocity_;
+
 protected:
     virtual bool serialize(std::ostream &stream) const
     {
@@ -61,7 +66,8 @@ protected:
             << "<do_shortcut>" << do_shortcut_ << "</do_shortcut>\n"
             << "<time_limit>" << time_limit_ << "</time_limit>\n"
             << "<blend_radius>" << blend_radius_ << "</blend_radius>\n"
-            << "<blend_iterations>" << blend_iterations_ << "</blend_iterations>\n";
+            << "<blend_iterations>" << blend_iterations_ << "</blend_iterations>\n"
+            << "<use_velocity>" << use_velocity_ << "</use_velocity>\n";
 
         return !!stream;
     }
@@ -88,7 +94,8 @@ protected:
           || name == "blend_radius"
           || name == "blend_iterations"
           || name == "do_shortcut"
-          || name == "time_limit";
+          || name == "time_limit"
+          || name == "use_velocity";
 
         return is_processing_ ? PE_Support : PE_Pass;
     }
@@ -109,6 +116,8 @@ protected:
                 _ss >> do_shortcut_;
             } else if (name == "time_limit") {
                 _ss >> time_limit_;
+            } else if (name == "use_velocity") {
+                _ss >> use_velocity_;
             } else {
                 RAVELOG_WARN(str(format("unknown tag %s\n") % name));
             }

--- a/src/ParabolicSmoother.cpp
+++ b/src/ParabolicSmoother.cpp
@@ -238,10 +238,13 @@ OpenRAVE::PlannerStatus ParabolicSmoother::PlanPath(TrajectoryBasePtr traj)
     EnvironmentBasePtr const env = GetEnv();
     ConfigurationSpecification pos_cspec
         = parameters_->_configurationspecification;
+    ConfigurationSpecification traj_cspec
+        = traj->GetConfigurationSpecification();
+
 
     // TODO: How do we do this properly?
-    BOOST_FOREACH (ConfigurationSpecification::Group &group,
-                   pos_cspec._vgroups) {
+    BOOST_FOREACH(ConfigurationSpecification::Group &group,
+                  pos_cspec._vgroups) {
         group.interpolation = "quadratic";
     }
 
@@ -272,11 +275,23 @@ OpenRAVE::PlannerStatus ParabolicSmoother::PlanPath(TrajectoryBasePtr traj)
     // trajectory is piecewise linear and stops at each waypoint.
     std::vector<ParabolicRamp::Vector> milestones(traj->GetNumWaypoints());
     std::vector<ParabolicRamp::Vector> velocities(traj->GetNumWaypoints());
-    bool zero_velocity = true;
 
+    // Check whether this trajectory has all the required velocity groups.
+    bool has_velocities = true;
+    std::vector<ConfigurationSpecification::Group>::const_iterator it;
+    BOOST_FOREACH(ConfigurationSpecification::Group &group,
+                  vel_cspec._vgroups) {
+        it = traj_cspec.FindCompatibleGroup(group, true);
+        if (it == traj_cspec._vgroups.end()) {
+            has_velocities = false;
+        }
+    }
+
+    // Iterate through each waypoint and convert them to milestones.
     for (size_t iwaypoint = 0; iwaypoint < traj->GetNumWaypoints(); ++iwaypoint) {
         std::vector<OpenRAVE::dReal> waypoint;
         traj->GetWaypoint(iwaypoint, waypoint, pos_cspec);
+        BOOST_ASSERT(waypoint.size() == num_dof);
 
         // Fix small joint limit violations.
         for (size_t idof = 0; idof < num_dof; ++idof) {
@@ -288,29 +303,19 @@ OpenRAVE::PlannerStatus ParabolicSmoother::PlanPath(TrajectoryBasePtr traj)
             );
         }
 
-        BOOST_ASSERT(waypoint.size() == num_dof);
         milestones[iwaypoint] = Convert<double>(waypoint);
 
-        if (parameters_->use_velocity_){
+        // Convert velocities if available and required.
+        if (parameters_->use_velocity_ && has_velocities) {
             waypoint.clear();
             traj->GetWaypoint(iwaypoint, waypoint, vel_cspec);
-
-            // Check to see if the trajectory has zero velocity
-            if (zero_velocity){
-                for (int j = 0; j < waypoint.size(); ++j){
-                    if (waypoint[j] != 0.0){
-                        zero_velocity = false;
-                        break;
-                    }
-                }
-            }
             BOOST_ASSERT(waypoint.size() == num_dof);
             velocities[iwaypoint] = Convert<double>(waypoint);
         }
     }
 
     RAVELOG_DEBUG("Setting %d milestones.\n", milestones.size());
-    if (parameters_->use_velocity_ && !zero_velocity){
+    if (parameters_->use_velocity_ && has_velocities){
         dynamic_path.SetMilestones(milestones, velocities);
     } else{
         dynamic_path.SetMilestones(milestones);


### PR DESCRIPTION
Added support for retiming using initially timed trajectories.

This adds a `use_velocity` flag to the configuration structure, which defaults to `true`.  When `true`, if the provided trajectory includes a velocity group, this will extract the velocities from the trajectory and pass them in along with the position milestones for each waypoint.
