### PR TITLE
Added prpy retiming wrapper directly to this repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Boost REQUIRED COMPONENTS chrono system)
 ###################################
 ## catkin specific configuration ##
 ###################################
+catkin_python_setup()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['or_parabolicsmoother'],
+    package_dir={'': 'src'}
+)
+
+setup(**d)

--- a/src/or_parabolicsmoother/prpy/__init__.py
+++ b/src/or_parabolicsmoother/prpy/__init__.py
@@ -1,0 +1,2 @@
+from .retimer import HauserParabolicSmoother
+__all__ = [HauserParabolicSmoother]

--- a/src/or_parabolicsmoother/prpy/retimer.py
+++ b/src/or_parabolicsmoother/prpy/retimer.py
@@ -1,0 +1,32 @@
+from copy import deepcopy
+from prpy.planning.retimer import OpenRAVERetimer
+from prpy.planning.base import PlanningMethod
+
+
+class HauserParabolicSmoother(OpenRAVERetimer):
+    """
+    A prpy wrapper for the `or_parabolicsmoother` plugin.
+    """
+    def __init__(self, do_blend=True, do_shortcut=True, blend_radius=0.5,
+                 blend_iterations=0, timelimit=3., **kwargs):
+        super(HauserParabolicSmoother, self).__init__(
+                'HauserParabolicSmoother', **kwargs)
+
+        self.default_options.update({
+            'do_blend': int(do_blend),
+            'do_shortcut': int(do_shortcut),
+            'blend_radius': float(blend_radius),
+            'blend_iterations': int(blend_iterations),
+            'time_limit': float(timelimit),
+        })
+
+    @PlanningMethod
+    def RetimeTrajectory(self, robot, path, options=None, **kw_args):
+        # Copy the user-specified before passing them.
+        new_options = deepcopy(options) if options else dict()
+        if 'timelimit' in kw_args:
+            new_options['time_limit'] = kw_args['timelimit']
+
+        # Call the abstract retimer implementation.
+        return super(HauserParabolicSmoother, self).RetimeTrajectory(
+            robot, path, options=new_options, **kw_args)


### PR DESCRIPTION
This adds a `prpy.planning.Planner` directly to this package.  This is easier to tightly version with the C++ code in this codebase, but can still be easily selectively imported from `prpy` or other python libraries.